### PR TITLE
ci(GitHub): run the release step only on the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: npm run eslint
 
   release:
+    if: ${{ github.ref == 'refs/heads/main' }}
+
     needs: [test]
 
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.31.0",
         "@typescript-eslint/parser": "^5.31.0",
-        "eslint-config-binden-js": "^1.0.0"
+        "eslint-config-binden-js": "^1.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2202,9 +2202,9 @@
       }
     },
     "node_modules/eslint-config-binden-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-binden-js/-/eslint-config-binden-js-1.0.0.tgz",
-      "integrity": "sha512-DOY0mgDJwxu8WeG8TysGouzRbE5+1kr/6j7bS4be3QUHZR/eivuZgANh1VX3bLN0bbv2s1oRgsZzsF3PNlkzaw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-binden-js/-/eslint-config-binden-js-1.0.1.tgz",
+      "integrity": "sha512-LZs8avdmeFYSM4MEBqbXWLYK4ytgQ1sWUfw9fXpJa/FoHDf8FqDeXQYW7EmC0DBBkfE28rLgYiypNdT+PQIQbg==",
       "peer": true,
       "engines": {
         "node": ">=18.6.0",
@@ -10421,9 +10421,9 @@
       }
     },
     "eslint-config-binden-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-binden-js/-/eslint-config-binden-js-1.0.0.tgz",
-      "integrity": "sha512-DOY0mgDJwxu8WeG8TysGouzRbE5+1kr/6j7bS4be3QUHZR/eivuZgANh1VX3bLN0bbv2s1oRgsZzsF3PNlkzaw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-binden-js/-/eslint-config-binden-js-1.0.1.tgz",
+      "integrity": "sha512-LZs8avdmeFYSM4MEBqbXWLYK4ytgQ1sWUfw9fXpJa/FoHDf8FqDeXQYW7EmC0DBBkfE28rLgYiypNdT+PQIQbg==",
       "peer": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@binden/commitlint-config": "^1.0.0",
-        "@binden/semantic-release-config": "^1.0.0",
+        "@binden/semantic-release-config": "^1.1.0",
         "@binden/tsconfig": "^1.0.0",
         "husky": "^8.0.1",
         "lint-staged": "^13.0.3",
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@binden/semantic-release-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@binden/semantic-release-config/-/semantic-release-config-1.0.0.tgz",
-      "integrity": "sha512-YGr8SSEZl5+P4M+ZSne971TExayRWPS0C3zkwKUaYHtM9Wc0oYBPNl0JbzoBaNTan8j60mT/9LUdjmwYoMsYTg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@binden/semantic-release-config/-/semantic-release-config-1.1.0.tgz",
+      "integrity": "sha512-JEKiRZKNqNnIbu87odIaFzTrdncMyeXLhYAI3g6zVS8mSIjMhR5XwYCr30YI1fgBK2Vj7MaEFfcjJbPWy5Olkw==",
       "dev": true,
       "engines": {
         "node": ">=18.6.0",
@@ -8835,9 +8835,9 @@
       "requires": {}
     },
     "@binden/semantic-release-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@binden/semantic-release-config/-/semantic-release-config-1.0.0.tgz",
-      "integrity": "sha512-YGr8SSEZl5+P4M+ZSne971TExayRWPS0C3zkwKUaYHtM9Wc0oYBPNl0JbzoBaNTan8j60mT/9LUdjmwYoMsYTg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@binden/semantic-release-config/-/semantic-release-config-1.1.0.tgz",
+      "integrity": "sha512-JEKiRZKNqNnIbu87odIaFzTrdncMyeXLhYAI3g6zVS8mSIjMhR5XwYCr30YI1fgBK2Vj7MaEFfcjJbPWy5Olkw==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
-    "eslint-config-binden-js": "^1.0.0"
+    "eslint-config-binden-js": "^1.0.1"
   },
   "devDependencies": {
     "@binden/commitlint-config": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@binden/commitlint-config": "^1.0.0",
-    "@binden/semantic-release-config": "^1.0.0",
+    "@binden/semantic-release-config": "^1.1.0",
     "@binden/tsconfig": "^1.0.0",
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",


### PR DESCRIPTION
### peerDependencies

- bump `eslint-config-binden-js` from `v1.0.0` to `v1.0.1` - 22416f85b76a1260acf360121e2d37c17291722c
